### PR TITLE
Monitoring CloudFormation drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ At the moment, you can monitor:
 * [RDS database instance](marbot-rds.yml): [Launch Stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/monitoring-jump-start/marbot-rds.yml)
 * [RDS cluster (Aurora)](marbot-rds-cluster.yml): [Launch Stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/monitoring-jump-start/marbot-rds-cluster.yml)
 * [SQS queue](marbot-sqs-queue.yml): [Launch Stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/monitoring-jump-start/marbot-sqs-queue.yml)
+* [CloudFormation Drift Detection](marbot-cloudformation-drift.yml): [Launch Stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/monitoring-jump-start/marbot-cloudformation-drift.yml)
 
 ## License
 All templates are published under Apache License Version 2.0.

--- a/lambda-layer/README.md
+++ b/lambda-layer/README.md
@@ -1,0 +1,6 @@
+# Lambda Layer
+
+The `marbot-cloudformation-drift.yml` template makes use of a Lambda Layer which provides the latest AWS SDK version.
+
+
+Use the `deploy.sh` script to upload a new layer version. And CloudFormation StackSets to roll out the changes in all regions by using the `layer.yml` and `bucket.yml`.

--- a/lambda-layer/bucket.yml
+++ b/lambda-layer/bucket.yml
@@ -1,4 +1,17 @@
 ---
+# Copyright 2019 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'marbot.io: Bucket'
 Resources:

--- a/lambda-layer/bucket.yml
+++ b/lambda-layer/bucket.yml
@@ -4,5 +4,5 @@ Description: 'marbot.io: Bucket'
 Resources:
   Bucket:
     Type: 'AWS::S3::Bucket'
-    Properties: 
+    Properties:
       BucketName: !Sub monitoring-jump-start-layer-${AWS::Region}

--- a/lambda-layer/bucket.yml
+++ b/lambda-layer/bucket.yml
@@ -1,0 +1,8 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'marbot.io: Bucket'
+Resources:
+  Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties: 
+      BucketName: !Sub monitoring-jump-start-layer-${AWS::Region}

--- a/lambda-layer/deploy.sh
+++ b/lambda-layer/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+date=$(date +%s)
+
+npm install
+mkdir nodejs
+mv node_modules/ nodejs/
+zip -r layer.zip nodejs/
+
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-ap-south-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-eu-west-3/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-eu-north-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-eu-west-2/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-eu-west-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-ap-northeast-2/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-ap-northeast-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-sa-east-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-ca-central-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-ap-southeast-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-ap-southeast-2/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-eu-central-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-us-east-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-us-east-2/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-us-west-1/layer-${date}.zip
+aws s3 cp layer.zip s3://monitoring-jump-start-layer-us-west-2/layer-${date}.zip
+
+rm layer.zip
+rm -fR nodejs

--- a/lambda-layer/layer.yml
+++ b/lambda-layer/layer.yml
@@ -1,0 +1,23 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'marbot.io: Lambda Layer'
+Parameters:
+  ContentKey:
+    Description: 'The key of the S3 object - a ZIP file - including the layer content.'
+    Type: String
+Resources:
+  Layer:
+    Type: 'AWS::Lambda::LayerVersion'
+    Properties:
+      LayerName: 'monitoring-jump-start'
+      CompatibleRuntimes:
+      - 'nodejs8.10'
+      Content:
+        S3Bucket: !Sub monitoring-jump-start-layer-${AWS::Region}
+        S3Key: !Ref ContentKey
+  LayerPermission:
+    Type: 'AWS::Lambda::LayerVersionPermission'
+    Properties:
+      Action: 'lambda:GetLayerVersion'
+      LayerVersionArn: !Ref Layer
+      Principal: '*'

--- a/lambda-layer/layer.yml
+++ b/lambda-layer/layer.yml
@@ -1,4 +1,17 @@
 ---
+# Copyright 2019 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'marbot.io: Lambda Layer'
 Parameters:

--- a/lambda-layer/package-lock.json
+++ b/lambda-layer/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "monitoring-jump-start",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.395.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.395.0.tgz",
+      "integrity": "sha512-ldTTjctniZT4E2lq2z3D8Y2u+vpkp+laoEnDkXgjKXTKbiJ0QEtfWsUdx/IQ7awCt8stoxyqZK47DJOxIbRNoA==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/lambda-layer/package.json
+++ b/lambda-layer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "monitoring-jump-start",
+  "version": "1.0.0",
+  "description": "[![Build Status](https://travis-ci.org/marbot-io/monitoring-jump-start.svg?branch=master)](https://travis-ci.org/marbot-io/monitoring-jump-start)",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marbot-io/monitoring-jump-start.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/marbot-io/monitoring-jump-start/issues"
+  },
+  "homepage": "https://github.com/marbot-io/monitoring-jump-start#readme",
+  "dependencies": {
+    "aws-sdk": "^2.395.0"
+  }
+}

--- a/marbot-cloudformation-drift.yml
+++ b/marbot-cloudformation-drift.yml
@@ -37,6 +37,7 @@ Parameters:
     AllowedValues: [v1, dev]
   StackRegularExpression:
     Description: 'Regular expression used to filter CloudFormation stacks by name'
+    Type: String
     Default: '.*'
 Resources:
   ##########################################################################
@@ -513,7 +514,7 @@ Resources:
         Variables:
           REGION: !Ref 'AWS::Region'
           ACCOUNT: !Ref 'AWS::AccountId'
-          TOPIC_ARN:  !Ref Topic
+          TOPIC_ARN: !Ref Topic
       Code:
         ZipFile: |
           'use strict';
@@ -523,7 +524,7 @@ Resources:
           exports.handler = async (event, context) => {
             const url = `https://${process.env.REGION}.console.aws.amazon.com/cloudformation/home?region=${process.env.REGION}#/stacks/${querystring.escape(event.stackArn)}/drifts`;
             const msg = {
-              Account: process.env.ACCOUNT, 
+              Account: process.env.ACCOUNT,
               Region: process.env.REGION,
               Stack: `<${url}|${event.stackName}>`,
               Message: CloudFormation drift detected, stage changed from ${event.previousDriftStatus} to ${event.latestDriftStatus}.`,

--- a/marbot-cloudformation-drift.yml
+++ b/marbot-cloudformation-drift.yml
@@ -1,0 +1,548 @@
+---
+# Copyright 2019 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'marbot.io: CloudFormation Drift Detection (https://github.com/marbot-io/monitoring-jump-start)'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'marbot endpoint'
+      Parameters:
+      - EndpointId
+      - Stage
+    - Label:
+        default: 'Configuration'
+      Parameters:
+      - StackRegularExpression
+Parameters:
+  EndpointId:
+    Description: 'Your marbot endpoint ID (to get this value: select a Slack channel where marbot belongs to and send a message like this: "@marbot show me my endpoint id").'
+    Type: String
+  Stage:
+    Description: 'marbot stage (never change this!).'
+    Type: String
+    Default: v1
+    AllowedValues: [v1, dev]
+  StackRegularExpression:
+    Description: 'Regular expression used to filter CloudFormation stacks by name'
+    Default: '.*'
+Resources:
+  ##########################################################################
+  #                                                                        #
+  #                                 TOPIC                                  #
+  #                                                                        #
+  ##########################################################################
+  Topic:
+    Type: 'AWS::SNS::Topic'
+    Properties: {}
+  TopicEndpointSubscription:
+    Type: 'AWS::SNS::Subscription'
+    Properties:
+      DeliveryPolicy:
+        healthyRetryPolicy:
+          minDelayTarget: 1
+          maxDelayTarget: 60
+          numRetries: 100
+          numNoDelayRetries: 0
+          backoffFunction: exponential
+        throttlePolicy:
+          maxReceivesPerSecond: 1
+      Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
+      Protocol: https
+      TopicArn: !Ref Topic
+  ##########################################################################
+  #                                                                        #
+  #                             STATE MACHINE                              #
+  #                                                                        #
+  ##########################################################################
+  StateMachineRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: !Sub 'states.${AWS::Region}.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: 'lambda:InvokeFunction'
+            Resource:
+            - !GetAtt 'FunctionFetchDriftStatus.Arn'
+            - !GetAtt 'FunctionStartDriftDetection.Arn'
+            - !GetAtt 'FunctionFetchDetectionStatus.Arn'
+            - !GetAtt 'FunctionSendDriftNotification.Arn'
+  RoleTrigger:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: 'cloudformation:ListStacks'
+            Resource: '*'
+          - Effect: Allow
+            Action: 'states:StartExecution'
+            Resource: !Ref StateMachine
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: '*'
+  RoleFetchDriftStatus:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: 'cloudformation:DescribeStacks'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: '*'
+  RoleStartDriftDetection:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/ReadOnlyAccess' # needed for detecting drift
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'cloudformation:DetectStackDrift'
+            - 'cloudformation:DetectStackResourceDrift'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: '*'
+  RoleFetchDetectionStatus:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: 'cloudformation:DescribeStackDriftDetectionStatus'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: '*'
+  RoleSendDriftNotification:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: 'sns:Publish'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: '*'
+  Permission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref FunctionTrigger
+      Principal: 'events.amazonaws.com'
+      SourceArn: !GetAtt 'Rule.Arn'
+  Rule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      ScheduleExpression: 'rate(1 hour)'
+      State: ENABLED
+      Targets:
+      - Arn: !GetAtt 'FunctionTrigger.Arn'
+        Id: lambda
+  StateMachine:
+    Type: 'AWS::StepFunctions::StateMachine'
+    Properties:
+      DefinitionString: !Sub |
+        {
+          "Comment": "Detect drift of CloudFormation stack",
+          "StartAt": "FetchDriftStatus",
+          "TimeoutSeconds": 600,
+          "Version": "1.0",
+          "States": {
+            "FetchDriftStatus": {
+              "Type": "Task",
+              "Resource": "${FunctionFetchDriftStatus.Arn}",
+              "Retry": [{
+                "ErrorEquals": ["States.TaskFailed"],
+                "IntervalSeconds": 5,
+                "MaxAttempts": 30,
+                "BackoffRate": 2
+              }],
+              "Next": "StartDriftDetection"
+            },
+            "StartDriftDetection": {
+              "Type": "Task",
+              "Resource": "${FunctionStartDriftDetection.Arn}",
+              "Retry": [{
+                "ErrorEquals": ["States.TaskFailed"],
+                "IntervalSeconds": 5,
+                "MaxAttempts": 30,
+                "BackoffRate": 2
+              }],
+              "Next": "FetchDetectionStatus"
+            },
+            "FetchDetectionStatus": {
+              "Type": "Task",
+              "Resource": "${FunctionFetchDetectionStatus.Arn}",
+              "Retry": [{
+                "ErrorEquals": ["States.TaskFailed"],
+                "IntervalSeconds": 5,
+                "MaxAttempts": 30,
+                "BackoffRate": 2
+              }],
+              "Next": "ChoiceDetectionComplete"
+            },
+            "ChoiceDetectionComplete": {
+              "Type": "Choice",
+              "Choices": [{
+                "Variable": "$.detectionStatus",
+                "StringEquals": "DETECTION_COMPLETE",
+                "Next": "ChoiceDriftStatusChanged"
+              },
+              {
+                "Variable": "$.detectionStatus",
+                "StringEquals": "DETECTION_FAILED",
+                "Next": "ChoiceDriftStatusChanged"
+              }],
+              "Default": "Wait"
+            },
+            "Wait": {
+              "Type": "Wait",
+              "Seconds": 10,
+              "Next": "FetchDetectionStatus"
+            },
+            "ChoiceDriftStatusChanged": {
+              "Type": "Choice",
+              "Choices": [{
+                "And": [
+                  {
+                    "Variable": "$.previousDriftStatus",
+                    "StringEquals": "IN_SYNC"
+                  },
+                  {
+                    "Variable": "$.latestDriftStatus",
+                    "StringEquals": "DRIFTED"
+                  }
+                ],
+                "Next": "SendDriftNotification"
+              },
+              {
+                "And": [
+                  {
+                    "Variable": "$.previousDriftStatus",
+                    "StringEquals": "UNKNOWN"
+                  },
+                  {
+                    "Variable": "$.latestDriftStatus",
+                    "StringEquals": "DRIFTED"
+                  }
+                ],
+                "Next": "SendDriftNotification"
+              },
+              {
+                "And": [
+                  {
+                    "Variable": "$.previousDriftStatus",
+                    "StringEquals": "NOT_CHECKED"
+                  },
+                  {
+                    "Variable": "$.latestDriftStatus",
+                    "StringEquals": "DRIFTED"
+                  }
+                ],
+                "Next": "SendDriftNotification"
+              }],
+              "Default": "Done"
+            },
+            "SendDriftNotification": {
+              "Type": "Task",
+              "Resource": "${FunctionSendDriftNotification.Arn}",
+              "Retry": [{
+                "ErrorEquals": ["States.TaskFailed"],
+                "IntervalSeconds": 5,
+                "MaxAttempts": 30,
+                "BackoffRate": 2
+              }],
+              "Next": "Done"
+            },
+            "Done": {
+              "Type": "Succeed"
+            }
+          }
+        }
+      RoleArn: !GetAtt 'StateMachineRole.Arn'
+  ExecutionsFailedAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Failed state machine executions.'
+      Namespace: 'AWS/States'
+      MetricName: ExecutionsFailed
+      Dimensions:
+      - Name: StateMachineArn
+        Value: !Ref StateMachine
+      Statistic: Sum
+      Period: 300
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Threshold: 0
+      TreatMissingData: notBreaching
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - !Ref Topic
+  ExecutionsTimeoutAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Failed state machine executions.'
+      Namespace: 'AWS/States'
+      MetricName: ExecutionsTimedOut
+      Dimensions:
+      - Name: StateMachineArn
+        Value: !Ref StateMachine
+      Statistic: Sum
+      Period: 300
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      Threshold: 0
+      TreatMissingData: notBreaching
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - !Ref Topic
+  FunctionTrigger:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'index.handler'
+      Runtime: 'nodejs8.10'
+      Layers:
+      - !Sub 'arn:aws:lambda:${AWS::Region}:853553028582:layer:monitoring-jump-start:1'
+      MemorySize: 128
+      Timeout: 30
+      Role: !GetAtt 'RoleTrigger.Arn'
+      Environment:
+        Variables:
+          STATEMACHINE_ARN: !Ref StateMachine
+          STACK_REGEXP: !Ref StackRegularExpression
+      Code:
+        ZipFile: |
+          'use strict';
+          const AWS = require('aws-sdk')
+          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+          const stepfunctions = new AWS.StepFunctions({apiVersion: '2016-11-23'});
+
+          let trigger = async (nextToken) => {
+            let params = {
+              StackStatusFilter: ['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'UPDATE_ROLLBACK_COMPLETE', 'UPDATE_ROLLBACK_FAILED']
+            }
+            if (nextToken) {
+              params.NextToken = nextToken;
+            }
+            const listStacksResult = await cloudformation.listStacks(params).promise();
+            const stacks = listStacksResult.StackSummaries.filter(stack => stack.StackName.match(new RegExp(process.env.STACK_REGEXP)));
+            for (let stack of stacks) {
+              await stepfunctions.startExecution({stateMachineArn: process.env.STATEMACHINE_ARN, input: JSON.stringify({stackName: stack.StackName})}).promise();
+            }
+            if (listStacksResult.NextToken) {
+              trigger(listStacksResult.NextToken);
+            }
+          };
+
+          exports.handler = async (event, context) => {
+            await trigger();
+            return event;
+          };
+  LogGroupTrigger:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${FunctionTrigger}'
+      RetentionInDays: 30
+  FunctionFetchDriftStatus:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'index.handler'
+      Runtime: 'nodejs8.10'
+      Layers:
+      - !Sub 'arn:aws:lambda:${AWS::Region}:853553028582:layer:monitoring-jump-start:1'
+      MemorySize: 128
+      Timeout: 30
+      Role: !GetAtt 'RoleFetchDriftStatus.Arn'
+      Code:
+        ZipFile: |
+          'use strict';
+          const AWS = require('aws-sdk')
+          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+          exports.handler = async (event, context) => {
+            const result = await cloudformation.describeStacks({StackName: event.stackName}).promise();
+            const driftStatus = result.Stacks[0].DriftInformation.StackDriftStatus;
+            const arn = result.Stacks[0].StackId;
+            return Object.assign({}, event, {previousDriftStatus: driftStatus, stackArn: arn});
+          };
+  LogGroupFetchDriftStatus:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${FunctionFetchDriftStatus}'
+      RetentionInDays: 30
+  FunctionStartDriftDetection:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'index.handler'
+      Runtime: 'nodejs8.10'
+      Layers:
+      - !Sub 'arn:aws:lambda:${AWS::Region}:853553028582:layer:monitoring-jump-start:1'
+      MemorySize: 128
+      Timeout: 30
+      Role: !GetAtt 'RoleStartDriftDetection.Arn'
+      Code:
+        ZipFile: |
+          'use strict';
+          const AWS = require('aws-sdk')
+          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+          exports.handler = async (event, context) => {
+            const result = await cloudformation.detectStackDrift({StackName: event.stackName}).promise();
+            return Object.assign({}, event, {stackDriftDetectionId: result.StackDriftDetectionId});
+          };
+  LogGroupStartDriftDetection:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${FunctionStartDriftDetection}'
+      RetentionInDays: 30
+  FunctionFetchDetectionStatus:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'index.handler'
+      Runtime: 'nodejs8.10'
+      Layers:
+      - !Sub 'arn:aws:lambda:${AWS::Region}:853553028582:layer:monitoring-jump-start:1'
+      MemorySize: 128
+      Timeout: 30
+      Role: !GetAtt 'RoleFetchDetectionStatus.Arn'
+      Code:
+        ZipFile: |
+          'use strict';
+          const AWS = require('aws-sdk')
+          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+          exports.handler = async (event, context) => {
+            const result = await cloudformation.describeStackDriftDetectionStatus({StackDriftDetectionId: event.stackDriftDetectionId}).promise();
+            return Object.assign({}, event, {detectionStatus: result.DetectionStatus, latestDriftStatus: result.StackDriftStatus});
+          };
+  LogGroupFetchDetectionStatus:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${FunctionFetchDetectionStatus}'
+      RetentionInDays: 30
+  FunctionSendDriftNotification:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: 'index.handler'
+      Runtime: 'nodejs8.10'
+      Layers:
+      - !Sub 'arn:aws:lambda:${AWS::Region}:853553028582:layer:monitoring-jump-start:1'
+      MemorySize: 128
+      Timeout: 30
+      Role: !GetAtt 'RoleSendDriftNotification.Arn'
+      Environment:
+        Variables:
+          REGION: !Ref 'AWS::Region'
+          ACCOUNT: !Ref 'AWS::AccountId'
+          TOPIC_ARN:  !Ref Topic
+      Code:
+        ZipFile: |
+          'use strict';
+          const querystring = require("querystring");
+          const AWS = require('aws-sdk')
+          const sns = new AWS.SNS({apiVersion: '2010-03-31'});
+          exports.handler = async (event, context) => {
+            const url = `https://${process.env.REGION}.console.aws.amazon.com/cloudformation/home?region=${process.env.REGION}#/stacks/${querystring.escape(event.stackArn)}/drifts`;
+            const msg = {
+              Account: process.env.ACCOUNT, 
+              Region: process.env.REGION,
+              Stack: `<${url}|${event.stackName}>`,
+              Message: CloudFormation drift detected, stage changed from ${event.previousDriftStatus} to ${event.latestDriftStatus}.`,
+            }
+            await sns.publish({TopicArn: process.env.TOPIC_ARN, Message: JSON.stringify(msg)}).promise();
+            return event;
+          };
+  LogGroupSendDriftNotification:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${FunctionSendDriftNotification}'
+      RetentionInDays: 30
+Outputs:
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'
+  StackTemplate:
+    Description: 'Stack template.'
+    Value: 'marbot-cloudformation-drift'
+  StackVersion:
+    Description: 'Stack version.'
+    Value: '1.0.0'


### PR DESCRIPTION
Monitoring CloudFormation drift.

1. Lambda function triggers state machine for all stacks matching the `StackRegularExpression` parameter every hour.
1. The state machine triggers the following workflow.
  1. Get the current drift status of the stack.
  1. Start detecting drift for the stack.
  1. Wait until CloudFormation has finished detecting drift for the stack.
  1. Check if drift status changed from OK to DRIFT.
  1. Send alarm via SNS.

Note: The Lambda runtime does not include an up-to-date AWS SDK which is required to access drift detection. Using Lambda Layers as a workaround. Published a Lambda Layer which includes the latest AWS SDK (see `./lambda-layer/`).
