### PR TITLE
update period to the minumum value supported

### DIFF
--- a/marbot-sqs-queue.yml
+++ b/marbot-sqs-queue.yml
@@ -117,7 +117,7 @@ Resources:
       Namespace: 'AWS/SQS'
       OKActions:
       - !Ref Topic
-      Period: 60
+      Period: 300
       Statistic: Maximum
       Threshold: !Ref ApproximateAgeOfOldestMessageThreshold
       TreatMissingData: notBreaching
@@ -137,7 +137,7 @@ Resources:
       Namespace: 'AWS/SQS'
       OKActions:
       - !Ref Topic
-      Period: 60
+      Period: 300
       Statistic: Maximum
       Threshold: !Ref ApproximateNumberOfMessagesVisibleThreshold
       TreatMissingData: notBreaching


### PR DESCRIPTION
The minimum value is 300 seconds as CloudWatch metrics for your Amazon SQS queues are automatically collected and pushed to CloudWatch every five minutes.
see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-monitoring-using-cloudwatch.html

Any value less than 300 and your alarms will never fire.