### PR TITLE
Revert "update period to the minumum value supported"

### DIFF
--- a/marbot-sqs-queue.yml
+++ b/marbot-sqs-queue.yml
@@ -142,7 +142,7 @@ Resources:
       Namespace: 'AWS/SQS'
       OKActions:
       - !Ref Topic
-      Period: 300
+      Period: 60
       Statistic: Maximum
       Threshold: !Ref ApproximateAgeOfOldestMessageThreshold
       TreatMissingData: notBreaching
@@ -162,7 +162,7 @@ Resources:
       Namespace: 'AWS/SQS'
       OKActions:
       - !Ref Topic
-      Period: 300
+      Period: 60
       Statistic: Maximum
       Threshold: !Ref ApproximateNumberOfMessagesVisibleThreshold
       TreatMissingData: notBreaching


### PR DESCRIPTION
Reverts marbot-io/monitoring-jump-start#12

1 minute resolution is now supported.
https://aws.amazon.com/about-aws/whats-new/2020/01/amazon-sqs-now-supports-1-minute-cloudwatch-metrics-in-all-commercial-regions/