### PR TITLE
Workaround for serious SNS delays

### DIFF
--- a/marbot-auto-scaling-group.yml
+++ b/marbot-auto-scaling-group.yml
@@ -117,8 +117,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -265,4 +263,4 @@ Outputs:
     Value: 'marbot-auto-scaling-group'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.2.0'
+    Value: '1.3.0'

--- a/marbot-cloudformation-drift.yml
+++ b/marbot-cloudformation-drift.yml
@@ -73,8 +73,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -578,4 +576,4 @@ Outputs:
     Value: 'marbot-cloudformation-drift'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.2.0'
+    Value: '1.3.0'

--- a/marbot-cloudfront.yml
+++ b/marbot-cloudfront.yml
@@ -121,8 +121,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -271,4 +269,4 @@ Outputs:
     Value: 'marbot-cloudfront'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'

--- a/marbot-ec2-instance.yml
+++ b/marbot-ec2-instance.yml
@@ -125,8 +125,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -538,4 +536,4 @@ Outputs:
     Value: 'marbot-ec2-instance'
   StackVersion:
     Description: 'Stack version.'
-    Value: '2.3.0'
+    Value: '2.4.0'

--- a/marbot-ec2-instances.yml
+++ b/marbot-ec2-instances.yml
@@ -147,8 +147,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -463,4 +461,4 @@ Outputs:
     Value: 'marbot-ec2-instances'
   StackVersion:
     Description: 'Stack version.'
-    Value: '2.3.0'
+    Value: '2.4.0'

--- a/marbot-efs.yml
+++ b/marbot-efs.yml
@@ -93,8 +93,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -172,4 +170,4 @@ Outputs:
     Value: 'marbot-efs'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.1.0'
+    Value: '1.2.0'

--- a/marbot-elastic-beanstalk.config
+++ b/marbot-elastic-beanstalk.config
@@ -48,8 +48,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: {'Fn::Join': ['', ['https://api.marbot.io/v1/endpoint/', {'Fn::GetOptionSetting': {OptionName: MarbotEndpointId}}]]}
       Protocol: https
       TopicArn: {Ref: MarbotTopic}

--- a/marbot-elastic-beanstalk.yml
+++ b/marbot-elastic-beanstalk.yml
@@ -86,8 +86,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -249,4 +247,4 @@ Outputs:
     Value: 'marbot-elastic-beanstalk'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.3.0'
+    Value: '1.4.0'

--- a/marbot-elasticache-memcached.yml
+++ b/marbot-elasticache-memcached.yml
@@ -108,8 +108,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -350,4 +348,4 @@ Outputs:
     Value: 'marbot-elasticache-memcached'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.4.0'
+    Value: '1.5.0'

--- a/marbot-elasticsearch.yml
+++ b/marbot-elasticsearch.yml
@@ -139,8 +139,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -501,4 +499,4 @@ Outputs:
     Value: 'marbot-elasticsearch'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.2.0'
+    Value: '1.3.0'

--- a/marbot-lambda-function.yml
+++ b/marbot-lambda-function.yml
@@ -100,8 +100,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -184,4 +182,4 @@ Outputs:
     Value: 'marbot-lambda-function'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'

--- a/marbot-rds-cluster.yml
+++ b/marbot-rds-cluster.yml
@@ -110,8 +110,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -225,4 +223,4 @@ Outputs:
     Value: 'marbot-rds-cluster'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.4.0'
+    Value: '1.5.0'

--- a/marbot-rds.yml
+++ b/marbot-rds.yml
@@ -147,8 +147,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -367,4 +365,4 @@ Outputs:
     Value: 'marbot-rds'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.4.0'
+    Value: '1.5.0'

--- a/marbot-redshift.yml
+++ b/marbot-redshift.yml
@@ -133,8 +133,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -339,4 +337,4 @@ Outputs:
     Value: 'marbot-redshift'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'

--- a/marbot-repeated-task.yml
+++ b/marbot-repeated-task.yml
@@ -79,8 +79,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -134,4 +132,4 @@ Outputs:
     Value: 'marbot-repeated-task'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'

--- a/marbot-sqs-queue.yml
+++ b/marbot-sqs-queue.yml
@@ -100,8 +100,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -182,4 +180,4 @@ Outputs:
     Value: 'marbot-sqs-queue'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.3.0'
+    Value: '1.4.0'

--- a/marbot-standalone-topic.yml
+++ b/marbot-standalone-topic.yml
@@ -85,8 +85,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -120,7 +118,7 @@ Outputs:
     Value: 'marbot-standalone-topic'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'
   TopicName:
     Description: 'The name of the SNS topic.'
     Value: !GetAtt 'Topic.TopicName'

--- a/marbot-synthetics-website.yml
+++ b/marbot-synthetics-website.yml
@@ -129,8 +129,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -283,4 +281,4 @@ Outputs:
     Value: 'marbot-synthetics-website'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'

--- a/marbot-workspaces.yml
+++ b/marbot-workspaces.yml
@@ -82,8 +82,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -164,4 +162,4 @@ Outputs:
     Value: 'marbot-workspaces'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'

--- a/marbot.yml
+++ b/marbot.yml
@@ -346,8 +346,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: !Ref Topic
@@ -494,8 +492,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: 'arn:aws:sns:us-east-1:177427601217:ecs-optimized-amazon-ami-update'
@@ -511,8 +507,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: 'arn:aws:sns:us-east-1:137112412989:amazon-linux-ami-updates'
@@ -528,8 +522,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Sub 'https://api.marbot.io/${Stage}/endpoint/${EndpointId}'
       Protocol: https
       TopicArn: 'arn:aws:sns:us-east-1:137112412989:amazon-linux-2-ami-updates'
@@ -1365,7 +1357,7 @@ Outputs:
     Value: 'marbot'
   StackVersion:
     Description: 'Stack version.'
-    Value: '2.3.1'
+    Value: '2.4.0'
   TopicName:
     Description: 'The name of the SNS topic.'
     Value: !GetAtt 'Topic.TopicName'


### PR DESCRIPTION
SNS is delivering messages to HTTPS subscriptions with serious delays (~60 minutes). We have been in contact with AWS for more than 20 days about this issue. However, AWS hasn't fixed the problem and does not provide an ETA. Therefore, we have decided to implement a workaround by removing the throttling from our HTTPS subscriptions. Unluckily, you have to update the CloudFormation stacks based on marbot's jump start templates. By the way, marbot will remind you to update all active stacks within the next 30 days.