### PR TITLE
Disabling backup notifications by default

### DIFF
--- a/marbot.yml
+++ b/marbot.yml
@@ -341,7 +341,7 @@ Parameters:
   BackupNotifications:
     Description: 'Receive notifications about AWS Backup activities.'
     Type: String
-    Default: true
+    Default: false
     AllowedValues: [true, false]
   AthenaFailed:
     Description: 'Receive an alert, if Athena fails.'


### PR DESCRIPTION
Getting notified about successful backup jobs gets noisy quickly. Therefore, I'd recommend to change the default here. Let's keep notifications about failed jobs but disable the rest by default.

Do you agree @michaelwittig?