### PR TITLE
Monitoring Elastic Beanstalk 2.0

### DIFF
--- a/marbot-elastic-beanstalk.yml
+++ b/marbot-elastic-beanstalk.yml
@@ -149,7 +149,7 @@ Resources:
       State: ENABLED
       EventPattern:
         source:
-        - aws.elasticbeanstalk
+        - 'aws.elasticbeanstalk'
         detail-type:
         - !If [ElasticBeanstalkResourceStatusChangeEnabled, 'Elastic Beanstalk resource status change', !Ref 'AWS::NoValue']
         - !If [OtherResourceStatusChangeEnabled, 'Other resource status change', !Ref 'AWS::NoValue']

--- a/marbot.yml
+++ b/marbot.yml
@@ -365,7 +365,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
   ElasticBeanstalkFailed:
-    Description: 'Receive notifications when Elastic Beanstalk fails.'
+    Description: 'Receive an alert, if Elastic Beanstalk fails.'
     Type: String
     Default: true
     AllowedValues: [true, false]
@@ -1928,7 +1928,7 @@ Resources:
       Description: 'Elastic Beanstalk notifications. (created by marbot)'
       EventPattern:
         source:
-        - aws.elasticbeanstalk
+        - 'aws.elasticbeanstalk'
         detail-type:
         - 'Elastic Beanstalk resource status change'
         - 'Other resource status change'


### PR DESCRIPTION
Elastic Beanstalk sends notifications to EventBridge as well (see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.eventbridge.html). This simplifies the configuration, as it is possible to subscribe to events from multiple/all applications/environments. Also, there is no need for a custom resource any more. So a lot good arguments to switch to the EventBridge notifications.

Besides that, this is the first template sending events via EventBridge instead of using an SNS topic.

As the notifications - for example the format - changed, we need to modify marbot's backend as well.