### PR TITLE
Adding ECS Spot notifications

### DIFF
--- a/marbot.yml
+++ b/marbot.yml
@@ -261,7 +261,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
   ECSSpotInterruption:
-    Description: 'Receive a notification when an ECS Fargate Spot task gets interrupted or fails to launch.'
+    Description: 'Receive an alert, if an ECS Fargate Spot task gets interrupted or fails to launch.'
     Type: String
     Default: true
     AllowedValues: [true, false]

--- a/marbot.yml
+++ b/marbot.yml
@@ -259,6 +259,11 @@ Parameters:
     Type: String
     Default: true
     AllowedValues: [true, false]
+  ECSSpotNotifications:
+    Description: 'Receive a notification when an ECS Fargate Spot task gets interrupted or fails to launch.'
+    Type: String
+    Default: true
+    AllowedValues: [true, false]
   MacieAlert:
     Description: 'Receive an alert, if Macie fires an alert.'
     Type: String
@@ -410,6 +415,7 @@ Conditions:
   EC2SpotInstanceInterruptionEnabled: !Equals [!Ref EC2SpotInstanceInterruption, 'true']
   ECSServiceFailedEnabled: !Equals [!Ref ECSServiceFailed, 'true']
   ECSDeploymentFailedEnabled: !Equals [!Ref ECSDeploymentFailed, 'true']
+  ECSSpotNotificationsEnabled: !Equals [!Ref ECSSpotNotifications, 'true']
   MacieAlertEnabled: !Equals [!Ref MacieAlert, 'true']
   SecurityHubFindingEnabled: !Equals [!Ref SecurityHubFinding, 'true']
   SecurityHubInsightEnabled: !Equals [!Ref SecurityHubInsight, 'true']
@@ -1407,6 +1413,42 @@ Resources:
       Targets:
       - Arn: !Ref Topic
         Id: marbot
+  ECSSpotFailureEvent:
+    Condition: ECSSpotNotificationsEnabled
+    DependsOn: TopicEndpointSubscription
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: 'ECS Spot failure. (created by marbot)'
+      EventPattern:
+        source:
+        - 'aws.ecs'
+        'detail-type':
+        - 'ECS Service Action'
+        detail:
+          eventName:
+          - SERVICE_TASK_PLACEMENT_FAILURE
+      State: ENABLED
+      Targets:
+      - Arn: !Ref Topic
+        Id: marbot
+  ECSSpotInterruptionEvent:
+    Condition: ECSSpotNotificationsEnabled
+    DependsOn: TopicEndpointSubscription
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: 'ECS Spot interruption notice. (created by marbot)'
+      EventPattern:
+        source:
+        - 'aws.ecs'
+        'detail-type':
+        - 'ECS Task State Change'
+        detail:
+          stopCode:
+          - TerminationNotice
+      State: ENABLED
+      Targets:
+      - Arn: !Ref Topic
+        Id: marbot
   MacieAlertEvent:
     Condition: MacieAlertEnabled
     DependsOn: TopicEndpointSubscription
@@ -2041,7 +2083,7 @@ Outputs:
     Value: 'marbot'
   StackVersion:
     Description: 'Stack version.'
-    Value: '2.15.0'
+    Value: '2.16.0'
   TopicName:
     Description: 'The name of the SNS topic.'
     Value: !GetAtt 'Topic.TopicName'

--- a/marbot.yml
+++ b/marbot.yml
@@ -53,6 +53,7 @@ Metadata:
       - EC2SpotInstanceInterruption
       - ECSServiceFailed
       - ECSDeploymentFailed
+      - ECSSpotInterruption
       - MacieAlert
       - SecurityHubFinding
       - SecurityHubInsight
@@ -259,7 +260,7 @@ Parameters:
     Type: String
     Default: true
     AllowedValues: [true, false]
-  ECSSpotNotifications:
+  ECSSpotInterruption:
     Description: 'Receive a notification when an ECS Fargate Spot task gets interrupted or fails to launch.'
     Type: String
     Default: true
@@ -415,7 +416,7 @@ Conditions:
   EC2SpotInstanceInterruptionEnabled: !Equals [!Ref EC2SpotInstanceInterruption, 'true']
   ECSServiceFailedEnabled: !Equals [!Ref ECSServiceFailed, 'true']
   ECSDeploymentFailedEnabled: !Equals [!Ref ECSDeploymentFailed, 'true']
-  ECSSpotNotificationsEnabled: !Equals [!Ref ECSSpotNotifications, 'true']
+  ECSSpotInterruptionEnabled: !Equals [!Ref ECSSpotInterruption, 'true']
   MacieAlertEnabled: !Equals [!Ref MacieAlert, 'true']
   SecurityHubFindingEnabled: !Equals [!Ref SecurityHubFinding, 'true']
   SecurityHubInsightEnabled: !Equals [!Ref SecurityHubInsight, 'true']
@@ -1413,12 +1414,12 @@ Resources:
       Targets:
       - Arn: !Ref Topic
         Id: marbot
-  ECSSpotFailureEvent:
-    Condition: ECSSpotNotificationsEnabled
+  ECSSpotPlacementFailureEvent:
+    Condition: ECSSpotInterruptionEnabled
     DependsOn: TopicEndpointSubscription
     Type: 'AWS::Events::Rule'
     Properties:
-      Description: 'ECS Spot failure. (created by marbot)'
+      Description: 'ECS service scheduler was unable to acquire any Fargate Spot capacity. (created by marbot)'
       EventPattern:
         source:
         - 'aws.ecs'
@@ -1427,16 +1428,18 @@ Resources:
         detail:
           eventName:
           - SERVICE_TASK_PLACEMENT_FAILURE
+          reason:
+          - 'RESOURCE:FARGATE'
       State: ENABLED
       Targets:
       - Arn: !Ref Topic
         Id: marbot
   ECSSpotInterruptionEvent:
-    Condition: ECSSpotNotificationsEnabled
+    Condition: ECSSpotInterruptionEnabled
     DependsOn: TopicEndpointSubscription
     Type: 'AWS::Events::Rule'
     Properties:
-      Description: 'ECS Spot interruption notice. (created by marbot)'
+      Description: 'ECS task is stopping due to Fargate Spot interruption. (created by marbot)'
       EventPattern:
         source:
         - 'aws.ecs'

--- a/marbot.yml
+++ b/marbot.yml
@@ -517,7 +517,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot",
-            "StackVersion": "2.15.0",
+            "StackVersion": "2.16.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",


### PR DESCRIPTION
Adding notifications for ECS/Fargate Spot Interruptions and task launch errors when running out of spot capacity.

see https://aws.amazon.com/premiumsupport/knowledge-center/fargate-spot-termination-notice/