### PR TITLE
Fixing Macie Findings

### DIFF
--- a/marbot.yml
+++ b/marbot.yml
@@ -54,7 +54,7 @@ Metadata:
       - ECSServiceFailed
       - ECSDeploymentFailed
       - ECSSpotInterruption
-      - MacieAlert
+      - MacieFinding
       - SecurityHubFinding
       - SecurityHubInsight
       - OpsWorksDeploymentFailed
@@ -265,8 +265,8 @@ Parameters:
     Type: String
     Default: true
     AllowedValues: [true, false]
-  MacieAlert:
-    Description: 'Receive an alert, if Macie fires an alert.'
+  MacieFinding:
+    Description: 'Receive an alert, if Macie generates a new finding.'
     Type: String
     Default: true
     AllowedValues: [true, false]
@@ -417,7 +417,7 @@ Conditions:
   ECSServiceFailedEnabled: !Equals [!Ref ECSServiceFailed, 'true']
   ECSDeploymentFailedEnabled: !Equals [!Ref ECSDeploymentFailed, 'true']
   ECSSpotInterruptionEnabled: !Equals [!Ref ECSSpotInterruption, 'true']
-  MacieAlertEnabled: !Equals [!Ref MacieAlert, 'true']
+  MacieFindingEnabled: !Equals [!Ref MacieFinding, 'true']
   SecurityHubFindingEnabled: !Equals [!Ref SecurityHubFinding, 'true']
   SecurityHubInsightEnabled: !Equals [!Ref SecurityHubInsight, 'true']
   OpsWorksDeploymentFailedEnabled: !Equals [!Ref OpsWorksDeploymentFailed, 'true']
@@ -1452,20 +1452,20 @@ Resources:
       Targets:
       - Arn: !Ref Topic
         Id: marbot
-  MacieAlertEvent:
-    Condition: MacieAlertEnabled
+  MacieFindingEvent:
+    Condition: MacieFindingEnabled
     DependsOn: TopicEndpointSubscription
     Type: 'AWS::Events::Rule'
     Properties:
-      Description: 'Alerts (risk >= high) from AWS Macie. (created by marbot)'
+      Description: 'Findings (severity >= high) from AWS Macie. (created by marbot)'
       EventPattern:
         source:
         - 'aws.macie'
         'detail-type':
-        - 'Macie Alert'
+        - 'Macie Finding'
         detail:
-          trigger:
-            risk: [{numeric: ['>=', 8]}]
+          severity:
+            score: [{numeric: ['>=', 3]}]
       State: ENABLED
       Targets:
       - Arn: !Ref Topic
@@ -2086,7 +2086,7 @@ Outputs:
     Value: 'marbot'
   StackVersion:
     Description: 'Stack version.'
-    Value: '2.16.0'
+    Value: '3.0.0'
   TopicName:
     Description: 'The name of the SNS topic.'
     Value: !GetAtt 'Topic.TopicName'

--- a/marbot.yml
+++ b/marbot.yml
@@ -518,7 +518,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot",
-            "StackVersion": "2.16.0",
+            "StackVersion": "3.0.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",


### PR DESCRIPTION

It seems like "Macie Alert" are no longer a thing. Therefore, I propose to filter for "Macie Findings".

https://docs.aws.amazon.com/macie/latest/user/findings-publish-event-schemas.html
https://docs.aws.amazon.com/macie/latest/user/findings-severity.html