### PR TITLE
fix: Monitoring Lambda functions

### DIFF
--- a/marbot-lambda-function.yml
+++ b/marbot-lambda-function.yml
@@ -119,7 +119,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot-lambda-function",
-            "StackVersion": "1.1.1",
+            "StackVersion": "1.1.2",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",
@@ -184,4 +184,4 @@ Outputs:
     Value: 'marbot-lambda-function'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.1.1'
+    Value: '1.1.2'

--- a/marbot-lambda-function.yml
+++ b/marbot-lambda-function.yml
@@ -140,11 +140,11 @@ Resources:
       - !Ref Topic
       AlarmDescription: 'Invocations failed due to errors'
       ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 1 # We use a 1 out of 3 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch
+      DatapointsToAlarm: 1 # We use a 1 out of 18 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch and the fact that Lambda uses the invocation timestamp for metric data
       Dimensions:
       - Name: FunctionName
         Value: !Ref FunctionName
-      EvaluationPeriods: 3 # We use a 1 out of 3 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch
+      EvaluationPeriods: 18 # We use a 1 out of 18 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch and the fact that Lambda uses the invocation timestamp for metric data
       MetricName: Errors
       Namespace: 'AWS/Lambda'
       OKActions:
@@ -162,11 +162,11 @@ Resources:
       - !Ref Topic
       AlarmDescription: 'Invocation attempts were throttled due to invocation rates exceeding the concurrent limits'
       ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 1 # We use a 1 out of 3 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch
+      DatapointsToAlarm: 1 # We use a 1 out of 18 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch and the fact that Lambda uses the invocation timestamp for metric data
       Dimensions:
       - Name: FunctionName
         Value: !Ref FunctionName
-      EvaluationPeriods: 3 # We use a 1 out of 3 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch
+      EvaluationPeriods: 18 # We use a 1 out of 18 alarm: if we only look at one period we might miss an error because of the eventual consistent nature of CloudWatch and the fact that Lambda uses the invocation timestamp for metric data
       MetricName: Throttles
       Namespace: 'AWS/Lambda'
       OKActions:

--- a/marbot.yml
+++ b/marbot.yml
@@ -525,7 +525,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot",
-            "StackVersion": "3.3.0",
+            "StackVersion": "3.2.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",
@@ -2124,7 +2124,7 @@ Outputs:
     Value: 'marbot'
   StackVersion:
     Description: 'Stack version.'
-    Value: '3.3.0'
+    Value: '3.2.0'
   TopicName:
     Description: 'The name of the SNS topic.'
     Value: !GetAtt 'Topic.TopicName'

--- a/marbot.yml
+++ b/marbot.yml
@@ -525,7 +525,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot",
-            "StackVersion": "3.2.0",
+            "StackVersion": "3.3.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",
@@ -2124,7 +2124,7 @@ Outputs:
     Value: 'marbot'
   StackVersion:
     Description: 'Stack version.'
-    Value: '3.2.0'
+    Value: '3.3.0'
   TopicName:
     Description: 'The name of the SNS topic.'
     Value: !GetAtt 'Topic.TopicName'


### PR DESCRIPTION
Lambda uses the invocation timestamp when writing metric data to CloudWatch. Therefore, we have to look back 15 minutes - the maximum Lambda timeout - plus 3 minutes.

See https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html for details.