### PR TITLE
Upgrading to Node.js 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: '3.8'
     - run: |
-        pip install cfn-lint==0.61.0
+        pip install cfn-lint==0.79.8
         yamllint *.yml
         cfn-lint -t *.yml
         find . -name 'marbot*.yml' | while read file; do set -ex && grep -q "LICENSE-2.0" "$file"; done;

--- a/marbot-cloudformation-drift.yml
+++ b/marbot-cloudformation-drift.yml
@@ -92,7 +92,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot-cloudformation-drift",
-            "StackVersion": "1.5.0",
+            "StackVersion": "1.6.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",

--- a/marbot-cloudformation-drift.yml
+++ b/marbot-cloudformation-drift.yml
@@ -522,7 +522,7 @@ Resources:
       Code:
         ZipFile: |
           'use strict';
-          const { CloudFormationClient, DescribeStackDriftDetectionStatusCommand } = require('@aws-sdk/client-cloudformation'); 
+          const { CloudFormationClient, DescribeStackDriftDetectionStatusCommand } = require('@aws-sdk/client-cloudformation');
           const cloudformation = new CloudFormationClient({apiVersion: '2010-05-15'});
           exports.handler = async (event, context) => {
             const result = await cloudformation.send(new DescribeStackDriftDetectionStatusCommand({StackDriftDetectionId: event.stackDriftDetectionId}));

--- a/marbot-cloudformation-drift.yml
+++ b/marbot-cloudformation-drift.yml
@@ -425,7 +425,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: 'index.handler'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt 'RoleTrigger.Arn'
@@ -436,9 +436,10 @@ Resources:
       Code:
         ZipFile: |
           'use strict';
-          const AWS = require('aws-sdk')
-          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
-          const stepfunctions = new AWS.StepFunctions({apiVersion: '2016-11-23'});
+          const { CloudFormationClient, ListStacksCommand } = require('@aws-sdk/client-cloudformation');
+          const cloudformation = new CloudFormationClient({apiVersion: '2010-05-15'});
+          const { SFNClient, StartExecutionCommand } = require('@aws-sdk/client-sfn');
+          const stepfunctions = new SFNClient({apiVersion: '2016-11-23'});
           let trigger = async (nextToken) => {
             let params = {
               StackStatusFilter: ['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'UPDATE_ROLLBACK_COMPLETE', 'UPDATE_ROLLBACK_FAILED']
@@ -446,10 +447,10 @@ Resources:
             if (nextToken) {
               params.NextToken = nextToken;
             }
-            const listStacksResult = await cloudformation.listStacks(params).promise();
+            const listStacksResult = await cloudformation.send(new ListStacksCommand(params));
             const stacks = listStacksResult.StackSummaries.filter(stack => stack.StackName.match(new RegExp(process.env.STACK_REGEXP)));
             for (let stack of stacks) {
-              await stepfunctions.startExecution({stateMachineArn: process.env.STATEMACHINE_ARN, input: JSON.stringify({stackName: stack.StackName})}).promise();
+              await stepfunctions.send(new StartExecutionCommand({stateMachineArn: process.env.STATEMACHINE_ARN, input: JSON.stringify({stackName: stack.StackName})}));
             }
             if (listStacksResult.NextToken) {
               trigger(listStacksResult.NextToken);
@@ -468,17 +469,17 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: 'index.handler'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt 'RoleFetchDriftStatus.Arn'
       Code:
         ZipFile: |
           'use strict';
-          const AWS = require('aws-sdk')
-          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+          const { CloudFormationClient, DescribeStacksCommand } = require('@aws-sdk/client-cloudformation');
+          const cloudformation = new CloudFormationClient({apiVersion: '2010-05-15'});
           exports.handler = async (event, context) => {
-            const result = await cloudformation.describeStacks({StackName: event.stackName}).promise();
+            const result = await cloudformation.send(new DescribeStacksCommand({StackName: event.stackName}));
             const driftStatus = result.Stacks[0].DriftInformation.StackDriftStatus;
             const arn = result.Stacks[0].StackId;
             return Object.assign({}, event, {previousDriftStatus: driftStatus, stackArn: arn});
@@ -492,17 +493,17 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: 'index.handler'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt 'RoleStartDriftDetection.Arn'
       Code:
         ZipFile: |
           'use strict';
-          const AWS = require('aws-sdk')
-          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+          const { CloudFormationClient, DetectStackDriftCommand } = require('@aws-sdk/client-cloudformation');
+          const cloudformation = new CloudFormationClient({apiVersion: '2010-05-15'});
           exports.handler = async (event, context) => {
-            const result = await cloudformation.detectStackDrift({StackName: event.stackName}).promise();
+            const result = await cloudformation.send(new DetectStackDriftCommand({StackName: event.stackName}));
             return Object.assign({}, event, {stackDriftDetectionId: result.StackDriftDetectionId});
           };
   LogGroupStartDriftDetection:
@@ -514,17 +515,17 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: 'index.handler'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt 'RoleFetchDetectionStatus.Arn'
       Code:
         ZipFile: |
           'use strict';
-          const AWS = require('aws-sdk')
-          const cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+          const { CloudFormationClient, DescribeStackDriftDetectionStatusCommand } = require('@aws-sdk/client-cloudformation'); 
+          const cloudformation = new CloudFormationClient({apiVersion: '2010-05-15'});
           exports.handler = async (event, context) => {
-            const result = await cloudformation.describeStackDriftDetectionStatus({StackDriftDetectionId: event.stackDriftDetectionId}).promise();
+            const result = await cloudformation.send(new DescribeStackDriftDetectionStatusCommand({StackDriftDetectionId: event.stackDriftDetectionId}));
             return Object.assign({}, event, {detectionStatus: result.DetectionStatus, latestDriftStatus: result.StackDriftStatus});
           };
   LogGroupFetchDetectionStatus:
@@ -536,7 +537,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: 'index.handler'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt 'RoleSendDriftNotification.Arn'
@@ -549,8 +550,8 @@ Resources:
         ZipFile: |
           'use strict';
           const querystring = require('querystring');
-          const AWS = require('aws-sdk')
-          const sns = new AWS.SNS({apiVersion: '2010-03-31'});
+          const { SNSClient, PublishCommand } = require('@aws-sdk/client-sns');
+          const sns = new SNSClient({apiVersion: '2010-03-31'});
           exports.handler = async (event, context) => {
             const url = `https://console.aws.amazon.com/cloudformation/home?region=${process.env.REGION}#/stacks/drifts?stackId=${querystring.escape(event.stackArn)}`;
             const msg = {
@@ -560,7 +561,7 @@ Resources:
               Message: `CloudFormation drift detected, stage changed from ${event.previousDriftStatus} to ${event.latestDriftStatus}.`,
               'Quick Links': url
             }
-            await sns.publish({
+            await sns.send(new PublishCommand({
               TopicArn: process.env.TOPIC_ARN,
               Message: JSON.stringify(msg),
               MessageAttributes: {
@@ -569,7 +570,7 @@ Resources:
                   StringValue: event.stackArn
                 }
               }
-            }).promise();
+            }));
             return event;
           };
   LogGroupSendDriftNotification:
@@ -586,4 +587,4 @@ Outputs:
     Value: 'marbot-cloudformation-drift'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.5.0'
+    Value: '1.6.0'

--- a/marbot-ec2-instance.yml
+++ b/marbot-ec2-instance.yml
@@ -445,9 +445,9 @@ Resources:
         ZipFile: |
           'use strict';
           const https = require('https');
-          const AWS = require('aws-sdk');
           const response = require('cfn-response');
-          const ec2 = new AWS.EC2({apiVersion: '2016-11-15'});
+          const { EC2Client, DescribeInstancesCommand } = require('@aws-sdk/client-ec2');
+          const ec2 = new EC2Client({apiVersion: '2016-11-15'});
           function getData(cb) {
             https.get('https://s3-eu-west-1.amazonaws.com/monitoring-jump-start/data/network.json', (res) => {
               if (res.statusCode === 200) {
@@ -482,9 +482,9 @@ Resources:
                   console.log(`Error: ${JSON.stringify(err)}`);
                   response.send(event, context, response.FAILED, {});
                 } else {
-                  ec2.describeInstances({
+                  ec2.send(new DescribeInstancesCommand({
                     InstanceIds: [event.ResourceProperties.InstanceId]
-                  }, (err, instanceData) => {
+                  }), (err, instanceData) => {
                     if (err) {
                       console.log(`Error: ${JSON.stringify(err)}`);
                       response.send(event, context, response.FAILED, {});
@@ -522,7 +522,7 @@ Resources:
       Handler: 'index.handler'
       MemorySize: 128
       Role: !GetAtt 'LambdaRole.Arn'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       Timeout: 60
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
@@ -538,4 +538,4 @@ Outputs:
     Value: 'marbot-ec2-instance'
   StackVersion:
     Description: 'Stack version.'
-    Value: '2.5.0'
+    Value: '2.6.0'

--- a/marbot-ec2-instance.yml
+++ b/marbot-ec2-instance.yml
@@ -144,7 +144,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot-ec2-instance",
-            "StackVersion": "2.5.0",
+            "StackVersion": "2.6.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",

--- a/marbot-ec2-instances.yml
+++ b/marbot-ec2-instances.yml
@@ -166,7 +166,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot-ec2-instances",
-            "StackVersion": "2.5.0",
+            "StackVersion": "2.6.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",

--- a/marbot-ec2-instances.yml
+++ b/marbot-ec2-instances.yml
@@ -409,7 +409,7 @@ Resources:
                 } else {
                   ec2.send(new DescribeInstancesCommand({
                     InstanceIds: [event.ResourceProperties.InstanceId]
-                  }, (err, instanceData) => {
+                  }), (err, instanceData) => {
                     if (err) {
                       console.log(`Error: ${JSON.stringify(err)}`);
                       response.send(event, context, response.FAILED, {});

--- a/marbot-ec2-instances.yml
+++ b/marbot-ec2-instances.yml
@@ -370,9 +370,9 @@ Resources:
         ZipFile: |
           'use strict';
           const https = require('https');
-          const AWS = require('aws-sdk');
           const response = require('cfn-response');
-          const ec2 = new AWS.EC2({apiVersion: '2016-11-15'});
+          const { EC2Client, DescribeInstancesCommand } = require('@aws-sdk/client-ec2');
+          const ec2 = new EC2Client({apiVersion: '2016-11-15'});
           function getData(cb) {
             https.get('https://s3-eu-west-1.amazonaws.com/monitoring-jump-start/data/network.json', (res) => {
               if (res.statusCode === 200) {
@@ -407,7 +407,7 @@ Resources:
                   console.log(`Error: ${JSON.stringify(err)}`);
                   response.send(event, context, response.FAILED, {});
                 } else {
-                  ec2.describeInstances({
+                  ec2.send(new DescribeInstancesCommand({
                     InstanceIds: [event.ResourceProperties.InstanceId]
                   }, (err, instanceData) => {
                     if (err) {
@@ -447,7 +447,7 @@ Resources:
       Handler: 'index.handler'
       MemorySize: 128
       Role: !GetAtt 'LambdaRole.Arn'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       Timeout: 60
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
@@ -463,4 +463,4 @@ Outputs:
     Value: 'marbot-ec2-instances'
   StackVersion:
     Description: 'Stack version.'
-    Value: '2.5.0'
+    Value: '2.6.0'

--- a/marbot-elasticache-memcached.yml
+++ b/marbot-elasticache-memcached.yml
@@ -127,7 +127,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot-elasticache-memcached",
-            "StackVersion": "1.6.0",
+            "StackVersion": "1.7.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",

--- a/marbot-elasticache-memcached.yml
+++ b/marbot-elasticache-memcached.yml
@@ -219,8 +219,8 @@ Resources:
         ZipFile: |
           'use strict';
           const response = require('cfn-response');
-          const AWS = require('aws-sdk');
-          const elasticache = new AWS.ElastiCache({apiVersion: '2015-02-02'});
+          const { ElastiCacheClient, DescribeCacheClusterCommand, ModifyCacheClusterCommand } = require('@aws-sdk/client-elasticache');
+          const elasticache = new ElastiCacheClient({apiVersion: '2015-02-02'});
           exports.handler = (event, context, cb) => {
             console.log(JSON.stringify(event));
             const failed = (err) => {
@@ -237,9 +237,9 @@ Resources:
               }
             };
             const describe = (cacheClusterId, cb) => {
-              elasticache.describeCacheClusters({
+              elasticache.send(new DescribeCacheClusterCommand({
                 CacheClusterId: cacheClusterId,
-              }, function(err, data) {
+              }), function(err, data) {
                 if (err) {
                   failed(err);
                 } else {
@@ -254,12 +254,12 @@ Resources:
               });
             };
             const modify = (cacheClusterId, notificationTopicArn, notificationTopicStatus, cb) => {
-              elasticache.modifyCacheCluster({
+              elasticache.send(new ModifyCacheClusterCommand({
                 CacheClusterId: cacheClusterId,
                 ApplyImmediately: true,
                 NotificationTopicArn: notificationTopicArn,
                 NotificationTopicStatus: notificationTopicStatus
-              }, function(err, data) {
+              }), function(err, data) {
                 if (err) {
                   failed(err);
                 } else {
@@ -318,7 +318,7 @@ Resources:
       Handler: 'index.handler'
       MemorySize: 128
       Role: !GetAtt 'CustomNotificationTopicConfigurationRole.Arn'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       Timeout: 10
   CustomNotificationTopicConfigurationRole:
     Type: 'AWS::IAM::Role'
@@ -350,4 +350,4 @@ Outputs:
     Value: 'marbot-elasticache-memcached'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.6.0'
+    Value: '1.7.0'

--- a/marbot-elasticache-memcached.yml
+++ b/marbot-elasticache-memcached.yml
@@ -219,7 +219,7 @@ Resources:
         ZipFile: |
           'use strict';
           const response = require('cfn-response');
-          const { ElastiCacheClient, DescribeCacheClusterCommand, ModifyCacheClusterCommand } = require('@aws-sdk/client-elasticache');
+          const { ElastiCacheClient, DescribeCacheClustersCommand, ModifyCacheClusterCommand } = require('@aws-sdk/client-elasticache');
           const elasticache = new ElastiCacheClient({apiVersion: '2015-02-02'});
           exports.handler = (event, context, cb) => {
             console.log(JSON.stringify(event));
@@ -237,7 +237,7 @@ Resources:
               }
             };
             const describe = (cacheClusterId, cb) => {
-              elasticache.send(new DescribeCacheClusterCommand({
+              elasticache.send(new DescribeCacheClustersCommand({
                 CacheClusterId: cacheClusterId,
               }), function(err, data) {
                 if (err) {

--- a/marbot-interface-endpoint.yml
+++ b/marbot-interface-endpoint.yml
@@ -127,7 +127,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot-interface-endpoint",
-            "StackVersion": "1.0.0",
+            "StackVersion": "1.1.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",

--- a/marbot-interface-endpoint.yml
+++ b/marbot-interface-endpoint.yml
@@ -276,17 +276,17 @@ Resources:
       Code:
         ZipFile: |
           'use strict';
-          const AWS = require('aws-sdk');
           const response = require('cfn-response');
-          const ec2 = new AWS.EC2({apiVersion: '2016-11-15'});
+          const { EC2Client, DescribeVpcEndpointsCommand } = require('@aws-sdk/client-ec2');
+          const ec2 = new EC2Client({apiVersion: '2016-11-15'});
           exports.handler = (event, context) => {
             console.log(`Invoke: ${JSON.stringify(event)}`);
             if (event.RequestType === 'Delete') {
               response.send(event, context, response.SUCCESS, {});
             } else if (event.RequestType === 'Create' || event.RequestType === 'Update') {
-              ec2.describeVpcEndpoints({
+              ec2.send(new DescribeVpcEndpointsCommand({
                 VpcEndpointIds: [event.ResourceProperties.EndpointId]
-              }, (err, data) => {
+              }), (err, data) => {
                 if (err) {
                   console.log(`Error: ${JSON.stringify(err)}`);
                   response.send(event, context, response.FAILED, {});
@@ -304,7 +304,7 @@ Resources:
       Handler: 'index.handler'
       MemorySize: 128
       Role: !GetAtt 'LambdaRole.Arn'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       Timeout: 60
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
@@ -320,4 +320,4 @@ Outputs:
     Value: 'marbot-interface-endpoint'
   StackVersion:
     Description: 'Stack version.'
-    Value: '1.0.0'
+    Value: '1.1.0'

--- a/marbot.yml
+++ b/marbot.yml
@@ -845,7 +845,7 @@ Resources:
       Code:
         ZipFile: |
           'use strict';
-          const { CloudWatchClient, DescribeAlarmsCommand } = require('@aws-sdk/client-cloudwatch'); 
+          const { CloudWatchClient, DescribeAlarmsCommand } = require('@aws-sdk/client-cloudwatch');
           const cloudwatch = new CloudWatchClient({apiVersion: '2010-08-01'});
           const { SNSClient, PublishCommand } = require('@aws-sdk/client-sns');
           const sns = new SNSClient({apiVersion: '2010-03-31'});

--- a/marbot.yml
+++ b/marbot.yml
@@ -835,7 +835,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: 'index.handler'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       MemorySize: 1024
       Timeout: 30
       Role: !GetAtt 'CloudWatchAlarmFilterRole.Arn'
@@ -845,9 +845,10 @@ Resources:
       Code:
         ZipFile: |
           'use strict';
-          const AWS = require('aws-sdk')
-          const cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
-          const sns = new AWS.SNS({apiVersion: '2010-03-31'});
+          const { CloudWatchClient, DescribeAlarmsCommand } = require('@aws-sdk/client-cloudwatch'); 
+          const cloudwatch = new CloudWatchClient({apiVersion: '2010-08-01'});
+          const { SNSClient, PublishCommand } = require('@aws-sdk/client-sns');
+          const sns = new SNSClient({apiVersion: '2010-03-31'});
           const STATE2ACTION = {
             'ALARM': 'AlarmActions',
             'OK': 'OKActions',
@@ -855,10 +856,10 @@ Resources:
           };
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
-            const data = await cloudwatch.describeAlarms({
+            const data = await cloudwatch.send(new DescribeAlarmsCommand({
               AlarmNames: [event.detail.alarmName],
               MaxRecords: 1
-            }).promise();
+            }));
             const alarms = [...data.CompositeAlarms, ...data.MetricAlarms];
             console.log(JSON.stringify(alarms));
             if (alarms.length === 0) {
@@ -873,10 +874,10 @@ Resources:
                   console.log("drop");
                 } else {
                   console.log("publish");
-                  await sns.publish({
+                  await sns.send(new PublishCommand({
                     TopicArn: process.env.TOPIC_ARN,
                     Message: JSON.stringify(event)
-                  }).promise();
+                  }));
                 }
               }
             }
@@ -1517,18 +1518,18 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: 'index.handler'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       MemorySize: 1024
       Timeout: 30
       Role: !GetAtt 'SecurityHubWorkflowRole.Arn'
       Code:
         ZipFile: |
           'use strict';
-          const AWS = require('aws-sdk')
-          const securityhub = new AWS.SecurityHub({apiVersion: '2018-10-26'});
+          const { SecurityHubClient, BatchUpdateFindingsCommand } = require('@aws-sdk/client-securityhub');
+          const securityhub = new SecurityHubClient({apiVersion: '2018-10-26'});
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
-            await securityhub.batchUpdateFindings({
+            await securityhub.send(new BatchUpdateFindingsCommand({
               FindingIdentifiers: event.detail.findings.map((finding) => ({
                 Id: finding.Id,
                 ProductArn: finding.ProductArn
@@ -1536,7 +1537,7 @@ Resources:
               Workflow: {
                 Status: 'NOTIFIED'
               }
-            }).promise();
+            }));
           };
   SecurityHubWorkflowAlarmErrorsTooHigh:
     Condition: SecurityHubFindingEnabled
@@ -2093,7 +2094,7 @@ Resources:
       Handler: 'index.handler'
       MemorySize: 128
       Role: !GetAtt 'TestAlertFunctionRole.Arn'
-      Runtime: 'nodejs16.x'
+      Runtime: 'nodejs18.x'
       Timeout: 30
   TestAlertFunctionRole:
     Condition: TestEnabled
@@ -2124,7 +2125,7 @@ Outputs:
     Value: 'marbot'
   StackVersion:
     Description: 'Stack version.'
-    Value: '3.2.0'
+    Value: '3.3.0'
   TopicName:
     Description: 'The name of the SNS topic.'
     Value: !GetAtt 'Topic.TopicName'

--- a/marbot.yml
+++ b/marbot.yml
@@ -525,7 +525,7 @@ Resources:
           {
             "Type": "monitoring-jump-start-connection",
             "StackTemplate": "marbot",
-            "StackVersion": "3.2.0",
+            "StackVersion": "3.3.0",
             "Partition": "${AWS::Partition}",
             "AccountId": "${AWS::AccountId}",
             "Region": "${AWS::Region}",


### PR DESCRIPTION
Node.js 16 reaches EOL soon. Therefore, we need to upgrade to Node.js 18. Unfortunately, AWS ships the SDK v3 with the Node.js 18 runtime environment for Lambda.